### PR TITLE
Fix getDevices not work on Windows

### DIFF
--- a/src/jvmMain/kotlin/intentpusher/IntentPusherViewModel.kt
+++ b/src/jvmMain/kotlin/intentpusher/IntentPusherViewModel.kt
@@ -153,7 +153,7 @@ class IntentPusherViewModel(
                     SystemChecker(),
                     AdbPathHelper(SystemChecker())
                 ),
-                DeviceInfoParser()
+                DeviceInfoParser(SystemChecker())
             ),
             AdbPathHelper(SystemChecker())
         )

--- a/src/jvmMain/kotlin/utils/DeviceInfoParser.kt
+++ b/src/jvmMain/kotlin/utils/DeviceInfoParser.kt
@@ -1,6 +1,8 @@
 package utils
 
-class DeviceInfoParser {
+class DeviceInfoParser(
+    private val systemChecker: SystemChecker
+) {
     /* sample
 List of devices attached
 22141FDEE000TW	device
@@ -8,18 +10,19 @@ emulator-5554	device
      */
 
     fun parse(input: String): Map<String, List<String>> {
-        val stringRemovedFirstLine = input.substringAfter("\n")
+        val delimeter = lookUpDelimiter()
+        val stringRemovedFirstLine = input.substringAfter(delimeter)
         if (stringRemovedFirstLine.isBlank()) {
             return emptyMap()
         }
 
-        val lines = stringRemovedFirstLine.split("\n").filter { it.isNotEmpty() }
+        val lines = stringRemovedFirstLine.split(delimeter).filter { it.isNotEmpty() }
         val result = mutableMapOf<String, MutableList<String>>()
         for (line in lines) {
             val parts = line.split("\t")
             if (parts.size == 2) {
-                val key = parts.get(1)
-                val value = parts.get(0)
+                val key = parts[1]
+                val value = parts[0]
                 if (result.containsKey(key)) {
                     result[key]?.add(value)
                 } else {
@@ -28,5 +31,13 @@ emulator-5554	device
             }
         }
         return result
+    }
+
+    private fun lookUpDelimiter(): String {
+        return when (systemChecker.checkSystem()) {
+            OsPlatform.MAC, OsPlatform.LINUX -> "\n"
+            OsPlatform.WINDOWS -> "\r\n"
+            OsPlatform.OTHER -> "\n"
+        }
     }
 }

--- a/src/jvmTest/kotlin/utils/DeviceInfoParserTest.kt
+++ b/src/jvmTest/kotlin/utils/DeviceInfoParserTest.kt
@@ -1,20 +1,27 @@
 package utils
 
 import com.google.common.truth.Truth
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
 import org.junit.Before
 import org.junit.Test
 
 class DeviceInfoParserTest {
 
-    lateinit var deviceInfoParser: DeviceInfoParser
+    @MockK
+    lateinit var systemChecker: SystemChecker
+
+    private lateinit var deviceInfoParser: DeviceInfoParser
 
     @Before
     fun setup() {
-        deviceInfoParser = DeviceInfoParser()
+        MockKAnnotations.init(this)
+        deviceInfoParser = DeviceInfoParser(systemChecker)
     }
 
     @Test
-    fun parseWithTwoConnectedDevices() {
+    fun parseWithTwoConnectedDevicesOnMac() {
         /*  Sample Input
             List of devices attached
             22141FDEE000TW	device
@@ -26,6 +33,7 @@ class DeviceInfoParserTest {
 
         // Given
         val sampleInput = "List of devices attached\n22141FDEE000TW\tdevice\nemulator-5554\tdevice\n\n"
+        every { systemChecker.checkSystem() } returns OsPlatform.MAC
 
         // When
         val resultMap = deviceInfoParser.parse(sampleInput)
@@ -37,7 +45,7 @@ class DeviceInfoParserTest {
     }
 
     @Test
-    fun parseWithNoConnectedDevices() {
+    fun parseWithNoConnectedDevicesOnMac() {
         /*  Sample Input
             List of devices attached
          */
@@ -47,6 +55,51 @@ class DeviceInfoParserTest {
 
         // Given
         val sampleInput = "List of devices attached\n\n"
+        every { systemChecker.checkSystem() } returns OsPlatform.MAC
+
+        // When
+        val resultMap = deviceInfoParser.parse(sampleInput)
+
+        // Then
+        Truth.assertThat(resultMap.size).isEqualTo(0)
+        Truth.assertThat(resultMap.containsKey("device")).isFalse()
+    }
+
+    @Test
+    fun parseWithConnectedDevicesOnWindows() {
+        /*  Sample Input
+            List of devices attached
+            emulator-5554	device
+         */
+
+        // Expected: Map<deviceType: String, deviceNames: List<String>>
+        // e.g. mapOf("device" to listOf("emulator-5554")
+
+        // Given
+        val sampleInput = "List of devices attached\r\nemulator-5554\tdevice\r\n\r\n"
+        every { systemChecker.checkSystem() } returns OsPlatform.WINDOWS
+
+        // When
+        val resultMap = deviceInfoParser.parse(sampleInput)
+
+        // Then
+        Truth.assertThat(resultMap.size).isGreaterThan(0)
+        Truth.assertThat(resultMap.containsKey("device")).isTrue()
+        Truth.assertThat(resultMap["device"]?.first()).isEqualTo("emulator-5554")
+    }
+
+    @Test
+    fun parseWithNoConnectedDevicesOnWindows() {
+        /*  Sample Input
+            List of devices attached
+         */
+
+        // Expected: Map<deviceType: String, deviceNames: List<String>>
+        // e.g. emptyMap()
+
+        // Given
+        val sampleInput = "List of devices attached\r\n\r\n"
+        every { systemChecker.checkSystem() } returns OsPlatform.WINDOWS
 
         // When
         val resultMap = deviceInfoParser.parse(sampleInput)


### PR DESCRIPTION
## Change
  - Support look up for delimiter in different platform
  - Windows use `\r\n` to wrapping text

### Screenshot
<img width="800" src="https://user-images.githubusercontent.com/4803452/236091481-c11f6795-9ac3-4d2e-ac11-950bbe808144.png">
